### PR TITLE
weCareAbout() cares about nulls

### DIFF
--- a/icepick.js
+++ b/icepick.js
@@ -14,7 +14,7 @@ var i = exports;
 
 // we only care about objects or arrays for now
 function weCareAbout(val) {
-  return Array.isArray(val) || (typeof val === "object");
+  return null !== val && (Array.isArray(val) || (typeof val === "object"));
 }
 
 function arrayClone(arr) {


### PR DESCRIPTION
`weCareAbout()` returns `true` for `null`.