### PR TITLE
Maintain prototype when cloning non-array.

### DIFF
--- a/icepick.js
+++ b/icepick.js
@@ -46,7 +46,7 @@ function objClone(obj) {
     keys = Object.keys(obj),
     length = keys.length,
     key,
-    result = {};
+    result = Object.create(Object.getPrototypeOf(obj));
 
   for (; index < length; index += 1) {
     key = keys[index];


### PR DESCRIPTION
Current objClone implementation loses prototype information.

This PR creates a clone (result) with the same prototype as the source obj.

This allows for richer immutable value objects with methods that can also be frozen and benefit from assoc/dissoc, etc.