### PR TITLE
add optional 'resolver' function as 3rd arg to .merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ var o1 = i.freeze({a: 1, b: {c: [1, 1]}, d: 1});
 var o2 = i.freeze({a: 2, b: {c: [2]}});
 
 function resolver(targetVal, sourceVal, key) {
-  if (Array.isArray(targetVal)) {
+  if (Array.isArray(targetVal) && sourceVal) {
     return targetVal.concat(sourceVal);
   } else {
     return sourceVal;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # icepick [![Build Status via Travis CI](https://travis-ci.org/aearly/icepick.svg?branch=master)](https://travis-ci.org/aearly/icepick) [![NPM version](http://img.shields.io/npm/v/icepick.svg)](https://www.npmjs.org/package/icepick) [![Coverage Status](https://coveralls.io/repos/aearly/icepick/badge.svg?branch=)](https://coveralls.io/r/aearly/icepick?branch=)
 
-Utilities for treating frozen JavaScript objects as persistent immutable collections. 
+Utilities for treating frozen JavaScript objects as persistent immutable collections.
 
 ## Motivation
 
@@ -200,7 +200,7 @@ var result = i.assign(obj1, obj2); // {a: 1, b: 2, c: 4, d: 5}
 assert(obj1 !== result); // true
 ```
 
-### merge(target, source)
+### merge(target, source, [associator])
 
 Deeply merge a `source` object into `target`, similar to Lodash.merge.  Child collections that are both frozen and reference equal will be assumed to be deeply equal.  Arrays from the `source` object will completely replace those in the `target` object if the two differ.  If nothing changed, the original reference will not change.  Returns a frozen object, and works with both unfrozen and frozen objects.
 
@@ -216,6 +216,24 @@ var result2 = i.merge(result1, obj2);
 assert(result1 === result2); // true
 
 ```
+
+An optional `resolver` function can be given as the third argument to change the way values are merged. For example, if you'd prefer that Array values from source be concatenated to target (instead of the source Array just replacing the target Array):
+
+var o1 = i.freeze({a: 1, b: {c: [1, 1]}, d: 1});
+var o2 = i.freeze({a: 2, b: {c: [2]}});
+
+function resolver(targetVal, sourceVal, key) {
+  if (Array.isArray(targetVal)) {
+    return targetVal.concat(sourceVal);
+  } else {
+    return sourceVal;
+  }
+}
+
+var result3 = i.merge(o1, o2, resolver);
+assert(result === {a: 2, b: {c: [1, 1, 2]}, d: 1});
+
+The `resolver` function receives three arguments: the value from the target object, the value from the source object, and the key of the value being merged.
 
 ### Array.prototype methods
 
@@ -259,7 +277,7 @@ Array methods like `find` or `indexOf` are not added to `icepick`, because you c
 ```js
 var arr = i.freeze([{a: 1}, {b: 2}]);
 
-arr.find(function (item) { return item.b != null; }); // {b: 2} 
+arr.find(function (item) { return item.b != null; }); // {b: 2}
 ```
 
 ### chain(coll)

--- a/icepick.js
+++ b/icepick.js
@@ -290,11 +290,8 @@ function merge(target, source, resolver) {
         return i.assoc(obj, key, resolvedSourceVal);
       }
       // recursively merge pairs of objects
-      return assocIfDifferent(
-        obj, key,
-        merge(targetVal, resolvedSourceVal, resolver),
-        i.assoc
-      );
+      return assocIfDifferent(obj, key,
+        merge(targetVal, resolvedSourceVal, resolver));
     }
 
     // primitive values, stuff with prototypes

--- a/icepick.js
+++ b/icepick.js
@@ -265,7 +265,7 @@ function singleAssign(obj1, obj2) {
 }
 
 exports.merge = merge;
-function merge(target, source) {
+function merge(target, source, resolver) {
   if (target == null || source == null) {
     return target;
   }
@@ -273,24 +273,32 @@ function merge(target, source) {
     var sourceVal = source[key];
     var targetVal = obj[key];
 
+    var resolvedSourceVal =
+      resolver ? resolver(targetVal, sourceVal, key) : sourceVal;
+
     if (weCareAbout(sourceVal) && weCareAbout(targetVal)) {
       // if they are both frozen and reference equal, assume they are deep equal
       if ((
-            (Object.isFrozen(sourceVal) && Object.isFrozen(targetVal)) ||
+            (Object.isFrozen(resolvedSourceVal) &&
+              Object.isFrozen(targetVal)) ||
             process.env.NODE_ENV === "production"
           ) &&
-          sourceVal === targetVal) {
+          resolvedSourceVal === targetVal) {
         return obj;
       }
       if (Array.isArray(sourceVal)) {
-        return i.assoc(obj, key, sourceVal);
+        return i.assoc(obj, key, resolvedSourceVal);
       }
       // recursively merge pairs of objects
-      return assocIfDifferent(obj, key, merge(targetVal, sourceVal));
+      return assocIfDifferent(
+        obj, key,
+        merge(targetVal, resolvedSourceVal, resolver),
+        i.assoc
+      );
     }
 
     // primitive values, stuff with prototypes
-    return assocIfDifferent(obj, key, sourceVal);
+    return assocIfDifferent(obj, key, resolvedSourceVal);
   }, target);
 }
 

--- a/icepick.test.js
+++ b/icepick.test.js
@@ -432,6 +432,24 @@ describe("icepick", function () {
       expect(i.merge(undefined, {})).to.eql(undefined);
     });
 
+    describe("custom associator", function () {
+      it("should use the custom associator", function () {
+        var o1 = i.freeze({a: 1, b: {c: [1, 1]}, d: 1});
+        var o2 = i.freeze({a: 2, b: {c: [2]}});
+
+        function resolver(targetVal, sourceVal) {
+          if (Array.isArray(targetVal)) {
+            return targetVal.concat(sourceVal);
+          } else {
+            return sourceVal;
+          }
+        }
+
+        var result = i.merge(o1, o2, resolver);
+        expect(result).to.eql({a: 2, b: {c: [1, 1, 2]}, d: 1});
+      });
+    });
+
   });
 
 });

--- a/icepick.test.js
+++ b/icepick.test.js
@@ -438,7 +438,7 @@ describe("icepick", function () {
         var o2 = i.freeze({a: 2, b: {c: [2]}});
 
         function resolver(targetVal, sourceVal) {
-          if (Array.isArray(targetVal)) {
+          if (Array.isArray(targetVal) && sourceVal) {
             return targetVal.concat(sourceVal);
           } else {
             return sourceVal;


### PR DESCRIPTION
This makes it possible to customize how `icepick.merge` resolves conflicting values.

See discussion in https://github.com/aearly/icepick/issues/17