### PR TITLE
assoc, assocIn, updateIn, and assign should keep references the same if nothing changes

### DIFF
--- a/icepick.js
+++ b/icepick.js
@@ -136,6 +136,10 @@ exports.thaw = function thaw(coll) {
  * @return {Object|Array}        new object hierarchy with modifications
  */
 exports.assoc = function assoc(coll, key, value) {
+  if (coll[key] === value) {
+    return _freeze(coll);
+  }
+
   var newObj = clone(coll);
 
   newObj[key] = freezeIfNeeded(value);
@@ -252,15 +256,14 @@ exports.slice = function slice(arr, arg1, arg2) {
 
 exports.extend =
 exports.assign = function assign(/*...objs*/) {
-  var newObj = _slice(arguments).reduce(singleAssign, {});
+  var newObj = rest(arguments).reduce(singleAssign, arguments[0]);
 
   return _freeze(newObj);
 };
 
 function singleAssign(obj1, obj2) {
   return Object.keys(obj2).reduce(function (obj, key) {
-    obj[key] = freezeIfNeeded(obj2[key]);
-    return obj;
+    return i.assoc(obj, key, obj2[key]);
   }, obj1);
 }
 

--- a/icepick.js
+++ b/icepick.js
@@ -79,7 +79,11 @@ function _freeze(coll) {
   if (process.env.NODE_ENV === "production") {
     return coll;
   }
-  return Object.freeze(coll);
+  if (typeof coll === "object") {
+    return Object.freeze(coll);
+  } else {
+    return coll;
+  }
 }
 
 function baseFreeze(coll, prevNodes) {

--- a/icepick.test.js
+++ b/icepick.test.js
@@ -119,6 +119,12 @@ describe("icepick", function () {
       expect(result.c).to.equal(o.c);
     });
 
+    it("should keep references the same if nothing changes", function () {
+      var o = i.freeze({a: 1});
+      var result = i.assoc(o, "a", 1);
+      expect(result).to.equal(o);
+    });
+
     it("should be aliased as set", function () {
       expect(i.set).to.equal(i.assoc);
     });
@@ -183,6 +189,12 @@ describe("icepick", function () {
     it("should be aliased as setIn", function () {
       expect(i.setIn).to.equal(i.assocIn);
     });
+
+    it("should keep references the same if nothing changes", function () {
+      var o = i.freeze({a: {b: 1}});
+      var result = i.assocIn(o, ["a", "b"], 1);
+      expect(result).to.equal(o);
+    });
   });
 
   describe("getIn", function () {
@@ -244,6 +256,12 @@ describe("icepick", function () {
         return 1;
       });
       expect(result).to.eql({a: {"1": {c: 1}}});
+    });
+
+    it("should keep references the same if nothing changes", function () {
+      var o = i.freeze({a: 1});
+      var result = i.updateIn(o, ["a", "b"], function (v) { return v; });
+      expect(result).to.equal(o);
     });
   });
 
@@ -375,6 +393,11 @@ describe("icepick", function () {
       expect(result).to.eql({a: 1, b: 3, c: 4, d: 4});
     });
 
+    it("should keep references the same if nothing changes", function () {
+      var o = i.freeze({a: 1});
+      var result = i.assign(o, {a: 1});
+      expect(result).to.equal(o);
+    });
   });
 
   describe("merge", function () {


### PR DESCRIPTION
I was surprised `merge` would keep the existing object(s) if nothing changed:

```
var a = { "foo": "bar" };
a === icepick.merge(a, { "foo": "bar" }); // true
```

while the rest of the updating methods (`assoc`, `assocIn`, `updateIn`, and `assign`) would create a new object even if nothing changed:

```
var b = { "foo": "bar" };
b === icepick.assoc(b, "foo", "bar"); // false
```

This fixes that.