### PR TITLE
Add support for cloning non-enumerable fields

### DIFF
--- a/icepick.js
+++ b/icepick.js
@@ -42,17 +42,21 @@ function arrayClone(arr) {
 }
 
 function objClone(obj) {
+  return Object.create(
+      Object.getPrototypeOf(obj),
+      makeDescriptorsWritable(Object.getOwnPropertyDescriptors(obj))
+  );
+}
+
+function makeDescriptorsWritable(descriptors) {
   var index = 0,
-    keys = Object.keys(obj),
-    length = keys.length,
-    key,
-    result = {};
+      keys = Object.keys(descriptors),
+      length = keys.length;
 
   for (; index < length; index += 1) {
-    key = keys[index];
-    result[key] = obj[key];
+    descriptors[keys[index]].writable = true;
   }
-  return result;
+  return descriptors;
 }
 
 function clone(coll) {


### PR DESCRIPTION
Currently `objClone` uses `Object.keys` to shallow clone objects. This means that non-enumerable properties are not copied when using operations such as `i.setIn`.

This PR refactors `objClone` to use `Object.create` and `Object.getOwnPropertyDescriptors` for shallow cloning (method adapted from [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors#Creating_a_shallow_clone)) and ensures to keep each field writable (since they are mutated shortly after in `assoc` before freezing.